### PR TITLE
Fix the module naming in package.json to match the dist folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,14 +44,14 @@
     "singleQuote": true,
     "trailingComma": "es5"
   },
-  "module": "dist/janus-gateway-ts.esm.js",
+  "module": "dist/janus-gateway-tsdx.esm.js",
   "size-limit": [
     {
-      "path": "dist/janus-gateway-ts.cjs.production.min.js",
+      "path": "dist/janus-gateway-tsdx.cjs.production.min.js",
       "limit": "10 KB"
     },
     {
-      "path": "dist/janus-gateway-ts.esm.js",
+      "path": "dist/janus-gateway-tsdx.esm.js",
       "limit": "10 KB"
     }
   ],


### PR DESCRIPTION
This is a minor change to update the package.json file to reflect the generated file names in package.json

Prior to this change, I was getting errors when trying to use the package as part of a Vue3 Vite app. 